### PR TITLE
Remove recursion in pull function.

### DIFF
--- a/miniKanren.dylan
+++ b/miniKanren.dylan
@@ -467,11 +467,14 @@ define function call/goal (g :: <goal>)
 end function call/goal;
 
 define function pull (stream :: <mk-stream>) => (forced :: <list>)
-  if (instance?(stream, <function>))
-    pull(stream());
-  else
-    stream;
-  end if;
+  iterate loop (s :: <mk-stream> = stream)
+    if (instance?(s, <function>))
+      let s :: <mk-stream> = s();
+      loop(s)
+    else
+      s
+    end if
+  end iterate
 end function pull;
 
 define function take (n :: <integer>, stream :: <mk-stream>)


### PR DESCRIPTION
Using recursion in the pull function was resulting in crashes due
to overflowing the stack. We can trivially eliminate that problem
by using the iterate macro to avoid doing actual recursion.
